### PR TITLE
Fix LaceworkSubAccountName to have Default

### DIFF
--- a/templates/lacework-aws-cfg-manage.template.yml
+++ b/templates/lacework-aws-cfg-manage.template.yml
@@ -56,6 +56,7 @@ Parameters:
   LaceworkSubAccountName:
     Type: String
     Description: "If Lacework Organizations is enabled, enter the sub-account. Leave blank if Lacework Organizations is not enabled."
+    Default: ''
     AllowedPattern: '^$|^[a-zA-Z0-9.]+(?:-[a-zA-Z0-9.]+)*$'
     ConstraintDescription: "Invalid Lacework account name entered. The account name may contain alphanumeric characters and dashes only."
   LaceworkAccessKeyID:


### PR DESCRIPTION
Without a "Default" property, the parameter `LaceworkSubAccountName` is required by CloudFormation. If that value is absent and no "Default" exists, `CreateChangeSet` responds with this error: `An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameters: [LaceworkSubAccountName] must have values.`