### PR TITLE
chore: use secret ARN instead of secret name for Lacework API credentials

### DIFF
--- a/functions/source/integration/lw_integration_lambda_function.py
+++ b/functions/source/integration/lw_integration_lambda_function.py
@@ -30,11 +30,12 @@ def handler(event, context):
     role_arn = event_message['ResourceProperties']['RoleArn']
     external_id = event_message['ResourceProperties']['ExternalId']
     account_id = event_message['ResourceProperties']['AccountId']
+    secret_name = event_message['ResourceProperties']['SecretName']
 
     logger.info('Request Type: %s', request_type)
     logger.info('Role ARN: %s', role_arn)
 
-    lacework_client = get_lacework_client(event_message, context)
+    lacework_client = get_lacework_client(secret_name, event_message, context)
 
     try:
         if request_type == 'Create':
@@ -180,8 +181,8 @@ def send_cfn_failure(event, context, message_text, exception=None):
     cfnresponse.send(event, context, cfnresponse.FAILED, response_data)
 
 
-def get_lacework_client(event, context):
-    secret_name = 'LaceworkApiCredentials'
+def get_lacework_client(secret_name, event, context):
+    # secret_name = 'LaceworkApiCredentials'
     region_name = os.environ['AWS_REGION']
 
     session = boto3.session.Session()

--- a/functions/source/integration/lw_integration_lambda_function.py
+++ b/functions/source/integration/lw_integration_lambda_function.py
@@ -30,12 +30,12 @@ def handler(event, context):
     role_arn = event_message['ResourceProperties']['RoleArn']
     external_id = event_message['ResourceProperties']['ExternalId']
     account_id = event_message['ResourceProperties']['AccountId']
-    secret_name = event_message['ResourceProperties']['SecretName']
+    secret_arn = event_message['ResourceProperties']['SecretArn']
 
     logger.info('Request Type: %s', request_type)
     logger.info('Role ARN: %s', role_arn)
 
-    lacework_client = get_lacework_client(secret_name, event_message, context)
+    lacework_client = get_lacework_client(secret_arn, event_message, context)
 
     try:
         if request_type == 'Create':
@@ -181,8 +181,7 @@ def send_cfn_failure(event, context, message_text, exception=None):
     cfnresponse.send(event, context, cfnresponse.FAILED, response_data)
 
 
-def get_lacework_client(secret_name, event, context):
-    # secret_name = 'LaceworkApiCredentials'
+def get_lacework_client(secret_arn, event, context):
     region_name = os.environ['AWS_REGION']
 
     session = boto3.session.Session()
@@ -193,14 +192,14 @@ def get_lacework_client(secret_name, event, context):
 
     try:
         get_secret_value_response = client.get_secret_value(
-            SecretId=secret_name
+            SecretId=secret_arn
         )
     except ClientError as error:
 
         err_msg = str(error)
 
         if error.response['Error']['Code'] == 'ResourceNotFoundException':
-            err_msg = f'The requested secret {secret_name} was not found'
+            err_msg = f'The requested secret {secret_arn} was not found'
         elif error.response['Error']['Code'] == 'InvalidRequestException':
             err_msg = f'The request was invalid due to: {err_msg}'
         elif error.response['Error']['Code'] == 'InvalidParameterException':

--- a/templates/lacework-aws-cfg-manage.template.yml
+++ b/templates/lacework-aws-cfg-manage.template.yml
@@ -251,7 +251,7 @@ Resources:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: Lacework API Access Keys
-      Name: LaceworkApiCredentials
+      Name: !Join ['-', ['LaceworkApiCredentials', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       SecretString:
         Fn::Join:
           - ''

--- a/templates/lacework-aws-cfg-manage.template.yml
+++ b/templates/lacework-aws-cfg-manage.template.yml
@@ -251,7 +251,6 @@ Resources:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: Lacework API Access Keys
-      Name: !Join ['-', ['LaceworkApiCredentials', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       SecretString:
         Fn::Join:
           - ''
@@ -324,6 +323,8 @@ Resources:
           ParameterValue: !Ref LaceworkAccountSNS
         - ParameterKey: ResourceNamePrefix
           ParameterValue: !Ref ResourceNamePrefix
+        - ParameterKey: SecretArn
+          ParameterValue: !GetAtt LaceworkApiCredentials.Id
       StackInstancesGroup:
         - Regions:
             - !Ref AWS::Region

--- a/templates/lacework-aws-cfg-member.template.yml
+++ b/templates/lacework-aws-cfg-member.template.yml
@@ -8,6 +8,7 @@ Metadata:
           - ResourceNamePrefix
           - LaceworkAccount
           - MainAccountSNS
+          - SecretArn
     ParameterLabels:
       ResourceNamePrefix:
         default: Resource name prefix
@@ -15,6 +16,8 @@ Metadata:
         default: Lacework Account
       MainAccountSNS:
         default: SNS Topic in main account
+      SecretArn:
+        default: AWS Secrets Manager secret ARN for Lacework API credentials
 
 Parameters:
   ResourceNamePrefix:
@@ -33,6 +36,9 @@ Parameters:
     ConstraintDescription: Invalid ExternalID value.  Must be between 2 and 1224 characters
   MainAccountSNS:
     Description: ARN of SNS topic that we post to start the integration
+    Type: String
+  SecretArn:
+    Description: AWS Secrets Manager secret ARN for Lacework API credentials
     Type: String
 
 Resources:
@@ -97,7 +103,7 @@ Resources:
       ExternalId: !Join [':',[!Sub "lweid:aws:v2:${LaceworkAccount}:${AWS::AccountId}", !Join ['',["LW",!Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ] ] ]]]]]
       AccountId:
         Ref: AWS::AccountId
-      SecretName: !Join ['-', ['LaceworkApiCredentials', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+      SecretArn: !Ref SecretArn
 
 Outputs:
   ExternalID:

--- a/templates/lacework-aws-cfg-member.template.yml
+++ b/templates/lacework-aws-cfg-member.template.yml
@@ -97,6 +97,7 @@ Resources:
       ExternalId: !Join [':',[!Sub "lweid:aws:v2:${LaceworkAccount}:${AWS::AccountId}", !Join ['',["LW",!Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ] ] ]]]]]
       AccountId:
         Ref: AWS::AccountId
+      SecretName: !Join ['-', ['LaceworkApiCredentials', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
 
 Outputs:
   ExternalID:


### PR DESCRIPTION
### Issue

https://lacework.atlassian.net/browse/GROW-2579

### Summary

Use the auto generated secret ARN instead of the hard-coded the secret name `LaceworkApiCredentials`