### PR TITLE
Revert "chore(deps): bump urllib3 from 1.26.15 to 2.5.0 in /functions/source/integration"

### DIFF
--- a/functions/source/integration/requirements.txt
+++ b/functions/source/integration/requirements.txt
@@ -1,3 +1,3 @@
 cfnresponse
 laceworksdk
-urllib3==2.5.0
+urllib3==1.26.15


### PR DESCRIPTION
Reverts lacework-alliances/aws-org-cf-lacework#35